### PR TITLE
Attendee could have no status from Api payload

### DIFF
--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -303,12 +303,14 @@ class Event extends AbstractEvent
             }
 
             $participation = new EventParticipation($event, $user, $role, EventParticipation::STATUS_NONE);
-            $participation->setStatus(EventParticipation::translateStatus($attendee['Status']['Response']));
-            $participation->setType(EventParticipation::translateType($attendee['Type']));
+            if (isset($attendee['Status'])) {
+                $participation->setStatus(EventParticipation::translateStatus($attendee['Status']['Response']));
 
-            if (EventParticipation::STATUS_NONE !== $participation->getStatus()) {
-                $participation->setAnsweredAt(new Datetime($attendee['Status']['Time']));
+                if (EventParticipation::STATUS_NONE !== $participation->getStatus()) {
+                    $participation->setAnsweredAt(new Datetime($attendee['Status']['Time']));
+                }
             }
+            $participation->setType(EventParticipation::translateType($attendee['Type']));
 
             $user->addEvent($event);
             $event->participations->add($participation);


### PR DESCRIPTION
Sometimes, an attendee can have no `Status` key.
An example is visible from MSDN here:
https://msdn.microsoft.com/office/office365/APi/calendar-rest-operations#Createevents
