### PR TITLE
Some events can have no organizers

### DIFF
--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -303,8 +303,10 @@ class Event extends AbstractEvent
         $event->status = self::translateConstantToValue('STATUS_', $data['showAs']);
         $event->type = self::translateConstantToValue('TYPE_', $data['type']);
 
-        $event->owner = Office365Adapter::buildUser($data['organizer']);
-        $event->owner->addEvent($event);
+        if (isset($data['organizer'])) {
+            $event->owner = Office365Adapter::buildUser($data['organizer']);
+            $event->owner->addEvent($event);
+        }
 
         $event->participations = new ArrayCollection;
         $attendees = isset($data['attendees']) ? $data['attendees'] : [];
@@ -319,7 +321,7 @@ class Event extends AbstractEvent
             $user = Office365Adapter::buildUser($attendee);
             $role = EventParticipation::ROLE_PARTICIPANT;
 
-            if ($event->owner->getId() === $user->getId()) {
+            if (null !== $event->owner && $event->owner->getId() === $user->getId()) {
                 $role |= EventParticipation::ROLE_MANAGER;
             }
 

--- a/test/Model/EventTest.php
+++ b/test/Model/EventTest.php
@@ -36,4 +36,63 @@ class EventTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('2016-04-05T12:00:00+00:00', $event->getStart()->format('c'));
     }
+
+    public function testHydrateNoOwner()
+    {
+        $data = [
+            'id' => 1,
+            'changeKey' => "foo",
+            'createdDateTime' => "2016-03-30T13:16:46.2214781Z",
+            'lastModifiedDateTime' => "2016-03-30T13:16:51.9873431Z",
+            'start' => [
+                "dateTime" => "2016-04-05T12:00:00.0000000",
+                "timeZone" => "UTC",
+            ],
+            'end' => [
+                "dateTime" => "2016-04-05T15:00:00.0000000",
+                "timeZone" => "UTC",
+            ],
+            "recurrence" => null,
+            "isAllDay" => false,
+            "isCancelled" => false,
+            "categories" => [],
+            "importance" => "normal",
+            "showAs" => "busy",
+            "type" => "singleInstance"
+        ];
+
+        $event = Event::hydrate($data);
+
+        $this->assertNull($event->getOwner());
+    }
+
+    public function testHydrateOwnerNull()
+    {
+        $data = [
+            'id' => 1,
+            'changeKey' => "foo",
+            'createdDateTime' => "2016-03-30T13:16:46.2214781Z",
+            'lastModifiedDateTime' => "2016-03-30T13:16:51.9873431Z",
+            'start' => [
+                "dateTime" => "2016-04-05T12:00:00.0000000",
+                "timeZone" => "UTC",
+            ],
+            'end' => [
+                "dateTime" => "2016-04-05T15:00:00.0000000",
+                "timeZone" => "UTC",
+            ],
+            "recurrence" => null,
+            "isAllDay" => false,
+            "isCancelled" => false,
+            "categories" => [],
+            "importance" => "normal",
+            "showAs" => "busy",
+            "type" => "singleInstance",
+            'organizer' => null
+        ];
+
+        $event = Event::hydrate($data);
+
+        $this->assertNull($event->getOwner());
+    }
 }


### PR DESCRIPTION
Some events can have no organizers, so we can have some nasty errors such as `array expected, null given` for `buildUser`
