### PR TITLE
Use reponse handler with persist

### DIFF
--- a/src/Api/EventApi.php
+++ b/src/Api/EventApi.php
@@ -175,9 +175,7 @@ class EventApi implements EventApiInterface
         $request = $this->guzzle->createRequest($method, $url, $params);
         $response = $this->guzzle->send($request);
 
-        if (200 > $response->getStatusCode() || 300 <= $response->getStatusCode()) {
-            throw new ApiErrorException($response);
-        }
+        $this->handleResponse($response);
 
         return Event::hydrate($response->json());
     }


### PR DESCRIPTION
The persist method uses now the reponse handler to manage response code.
And fix the missing namespace of `ApiErrorException`.
