### PR TITLE
Fix a missing response status

### DIFF
--- a/src/Model/EventParticipation.php
+++ b/src/Model/EventParticipation.php
@@ -70,8 +70,11 @@ class EventParticipation extends BaseEventParticipation
             case 'declined':
                 return static::STATUS_DECLINED;
 
+            case 'organizer':
+                return static::STATUS_ORGANIZER;
+
             default:
-                throw new InvalidArgumentException(sprintf('Wrong status sent. Expected one of [\'none\', \'notResponded\', \'tentativelyAccepted\', \'accepted\', \'declined\'], had "%s"', $status));
+                throw new InvalidArgumentException(sprintf('Wrong status sent. Expected one of [\'none\', \'notResponded\', \'tentativelyAccepted\', \'accepted\', \'declined\', \'organizer\'], had "%s"', $status));
         }
     }
 


### PR DESCRIPTION
According to the documentation https://graph.microsoft.io/en-us/docs/api-reference/v1.0/resources/responsestatus
