### PR TITLE
import and throw good exception if something goes wrong in persist method

### DIFF
--- a/src/Api/EventApi.php
+++ b/src/Api/EventApi.php
@@ -11,6 +11,7 @@
 
 namespace CalendArt\Adapter\Office365\Api;
 
+use CalendArt\Adapter\Office365\Exception\BadRequestException;
 use GuzzleHttp\Client as Guzzle;
 
 use DateTime;
@@ -176,7 +177,7 @@ class EventApi implements EventApiInterface
         $response = $this->guzzle->send($request);
 
         if (200 > $response->getStatusCode() || 300 <= $response->getStatusCode()) {
-            throw new ApiErrorException($response);
+            throw new BadRequestException($response);
         }
 
         return Event::hydrate($response->json());


### PR DESCRIPTION
in `EventApi::persist` method a wrong exception was used : `ApiErrorException` which is abstract and never imported in the current namespace.

I replaced it by `BasRequestException` and imported it in the namespace.
