### PR TITLE
Revert "[EventParticipation] Remove wonky "Organizer" status"

### DIFF
--- a/src/Model/EventParticipation.php
+++ b/src/Model/EventParticipation.php
@@ -32,7 +32,7 @@ class EventParticipation extends BaseEventParticipation
     //const TYPE_RESOURCE = 2;
 
     const STATUS_NONE = null;
-    //const STATUS_ORGANIZER = 2;
+    const STATUS_ORGANIZER = 2;
 
     private $type = self::TYPE_OPTIONAL;
 
@@ -50,7 +50,7 @@ class EventParticipation extends BaseEventParticipation
     /** {@inheritDoc} */
     public static function getAvailableStatuses()
     {
-        return parent::getAvailableStatuses() + [static::STATUS_NONE];
+        return parent::getAvailableStatuses() + [static::STATUS_NONE, static::STATUS_ORGANIZER];
     }
 
     public static function translateStatus($status)


### PR DESCRIPTION
This reverts commit d0b34bead4a595fcffa85f8c29118efd6a3edc68.

The status organizer is currently needed by the `EventParticipation` (https://github.com/Calendart/Office365Adapter/blob/2e07a983cc2e01ab9598158473274279fc2ed290/src/Model/EventParticipation.php#L74)
